### PR TITLE
Fix Quick Start heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A PostgreSQL MCP server implementation using the [Model Context Protocol (MCP)](
 - Get foreign key information
 - Execute SQL queries
 
-## Quick Start
+## Quick Start
 
 ```bash
 # Run the server without a DB connection (useful for Glama or inspection)


### PR DESCRIPTION
## Summary
- fix `Quick Start` heading in README

## Testing
- `python -m py_compile postgres_server.py`
- `python postgres_server.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68407b368d6c8326b442bbc037859bc2